### PR TITLE
Add basic search to nodes

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -7,10 +7,23 @@
     <script defer data-domain="h4kor.github.io/fediverse-explorer" src="https://plausible.libove.org/js/plausible.js"></script>
     <title>Fediverse Explorer</title>
 </head>
-<body style="margin: 0; padding: 0; overflow: hidden;height: 100vh;background-color: #191b22;">
+<body style="margin: 0; padding: 0; overflow: hidden;height: 100vh;background-color: #191b22; color: white">
+    <h1>FediExplorer</h1>
+    <div>Search: <input type="text" id="searchBox"><p id="result"></p></div>
     <svg id="chart" width="100%" height="100%"></svg>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script>
+        // search function
+        document.getElementById("searchBox").onkeydown = function(e) {
+            if (event.key == "Enter") {
+                if (!highlightNode(e.target.value)) {
+                    document.getElementById('result').textContent = "could not exactly match for node";
+                } else {
+                    document.getElementById('result').textContent = "";
+                }
+            }
+        };
+
         // init box
         const min_x = -0.02;
         const max_x = 0.07;
@@ -25,7 +38,19 @@
 
         let zoom = d3.zoom()
             .on('zoom', handleZoom);
+
+        var searchNode = null;
         
+        function zoomTo(x, y) {
+            // FIXME: broken, copied from examples where the handlers are different
+            let transform = d3.zoomIdentity.translate(x, y);
+            let zoomBase = d3.select('svg');
+            // FIXME: this updates the data correctly but does not cause any animation
+            zoomBase
+                .transition()
+                .duration(5000)
+                .call(zoom.transform, transform);
+        }
 
         function handleZoom(e) {
             d3.select('svg g')
@@ -35,6 +60,37 @@
         function initZoom() {
             d3.select('svg')
                 .call(zoom);
+        }
+
+        function highlightNode(name) {
+            let nodeName = name.replaceAll(".", "\\.");
+            let node = d3.select("#node-"+nodeName).node();
+            if (node == null) {
+                console.log("cannot find node id: node-" + name);
+                return false;
+            }
+            if (searchNode != null) {
+                d3.select(searchNode).attr('mark', 'false');
+                recolorNode(searchNode);
+            }
+            searchNode = node;
+            d3.select(node).attr('mark', 'true');
+            recolorNode(node);
+            text.text(name);
+            return true;
+        }
+
+        function recolorNode(node) {
+            if (d3.select(node).attr('select') == 'true') {
+                // highlighted by mouse over
+                d3.select(node).attr("fill", "#00aaFF").attr("opacity", 1);
+            } else if (d3.select(node).attr('mark') == 'true') {
+                // highlighted by search
+                d3.select(node).attr("fill", "#FF0000").attr("opacity", 1);
+            } else {
+                // regular node
+                d3.select(node).attr("fill", "#ddaa00").attr("opacity", 0.5);
+            }
         }
 
         const g = svg.append("g");
@@ -48,13 +104,14 @@
             .attr("fill", "white")
             .attr("stroke", "black")
             .attr("stroke-width", "1px")
-            .text("FediExplorer");
+            .text("");
 
         d3.json("data.json").then(function(json) {
             g.selectAll("circle")
                 .data(json)
                 .enter()
                 .append("circle")
+                .attr("id", function(d) { return "node-" + d[0] })
                 .attr("cx", function(d) { return (d[1][0] - min_x) / (max_x - min_x) * Math.min(width, height); })
                 .attr("cy", function(d) { return (d[1][1] - min_y) / (max_y - min_y) * Math.min(width, height); })
                 .attr("r", 1)
@@ -63,12 +120,19 @@
                 .on("click", function(e, d) {
                    console.log(d[0]);
                    text.text(d[0]);
+                   if(searchNode != null) {
+                       d3.select(searchNode).attr('mark', 'false')
+                       recolorNode(searchNode)
+                       searchNode = null;
+                   }
                 })
                 .on("mouseover", function(e, d) {
-                    d3.select(this).attr("fill", "#00aaFF").attr("opacity", 1);
+                    d3.select(this).attr('select', 'true')
+                    recolorNode(this)
                 })
                 .on("mouseout", function(e, d) {
-                    d3.select(this).attr("fill", "#ddaa00").attr("opacity", 0.5);
+                    d3.select(this).attr('select', 'false')
+                    recolorNode(this)
                 });
             initZoom();        
         });


### PR DESCRIPTION
As requested elsewhere, a very crude search for nodes.

Entering an exact match at the search field on the top will cause the node to highlight in a bright red color. The highlight remains until the map is otherwise interacted with.

It currently needs some CSS to look nice, and I also failed to make it center and zoom. It seems the `d3.zoom` function is extremely counterintuitive to invoke externally.

Hopefully it's a worthwhile start, at least!